### PR TITLE
Implement compression phase

### DIFF
--- a/include/Periodic.hpp
+++ b/include/Periodic.hpp
@@ -18,3 +18,16 @@ public:
     ~Periodic();
     void Run(json parameter_json, int phase_index, std::string root_directory_of_data, double time_scale);
 };
+
+class PeriodicCompression
+{
+protected:
+    Rods &rods;
+    ParametersForRods &parameter;
+
+public:
+
+    PeriodicCompression(Rods &rods, ParametersForRods &parameter_for_rods);
+    ~PeriodicCompression();
+    void Run(json parameter_json, int phase_index, std::string root_directory_of_data, double time_scale, double initial_linear_dimension, double final_linear_dimension);
+};

--- a/project/periodic/parameters.json
+++ b/project/periodic/parameters.json
@@ -1,6 +1,9 @@
 {
   "project": "periodic",
-  "phases": [{ "name": "periodic", "given_total_times": 100 }],
+  "phases": [
+    { "name": "compress", "given_total_times": 100 },
+    { "name": "periodic", "given_total_times": 400 }
+  ],
   "with_boundary": false,
   "threads": 1,
   "given_time_interval_per_step": 0.002,


### PR DESCRIPTION
## Issue

Close #2 
## Implementation policy
- Create another phase for compression
- Run each phase in the order of Compression -> Periodic with RL

## What we did

- Create interface for Compression phase named PeriodicCompression
- Implement PeriodicCompression class
- Introduce PeriodicCompression phase to main function

## Result
- Simulation in Compression phase for area fraction = 0.6

https://github.com/zfoong/Intelligent-Agent-Driven-Active-Brownian-Particles/assets/48506727/75cd262a-7a98-420b-b529-549629ddde83

### How to make movie
```bash
cd project/periodic
vim parameters.json # edit area fraction to be 0.6
bash execute/cmake_and_run.sh
python3 execute/run.py
python3 visualize/track_rods.py --phase 0
ffmpeg -framerate 10 -pattern_type glob -i 'data/compress/fig/segments*000.png' -vcodec libx264 -acodec copy -pix_fmt yuv420p -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" -r 10 compression.mp4
```