### PR TITLE
Make script use argument

### DIFF
--- a/execute/run.py
+++ b/execute/run.py
@@ -35,8 +35,7 @@ if __name__ == "__main__":
     exec_file = working_dir + "bin/" + project_name
     print("exec file is " + exec_file)
 
-    with_boundary = params["with_boundary"]
-    mkdir(working_dir, with_boundary)
+    mkdir(working_dir)
 
     run(exec_file, parameter_file)
 

--- a/execute/setup.py
+++ b/execute/setup.py
@@ -2,7 +2,7 @@ import json
 import os
 
 
-def mkdir(working_dir, with_boundary=True):
+def mkdir(working_dir):
     data_dir = working_dir + "data/"
     print("data directory is " + data_dir)
 
@@ -11,16 +11,13 @@ def mkdir(working_dir, with_boundary=True):
     with open(parameter_file) as f:
         params = json.load(f)
     simulation_phases = params["phases"]
-
-    if with_boundary is True:
-        data_types = ["rods", "segments", "boundary", "fig"]
-    else:
-        data_types = ["rods", "segments", "fig"]
+    data_types = params["data_types"]
 
     for simulation_phase in simulation_phases:
         for data_type in data_types:
             os.makedirs(
-                data_dir + simulation_phase["name"] + "/" + data_type, exist_ok=True
+                data_dir + simulation_phase["name"] + "/" + data_type,
+                exist_ok=True
             )
 
 

--- a/project/periodic/parameters.json
+++ b/project/periodic/parameters.json
@@ -4,7 +4,7 @@
     { "name": "compress", "given_total_times": 100 },
     { "name": "periodic", "given_total_times": 400 }
   ],
-  "with_boundary": false,
+  "data_types": ["rods", "segments", "fig"],
   "threads": 1,
   "given_time_interval_per_step": 0.002,
   "step_interval_for_output": 1000,

--- a/visualize/track_rods.py
+++ b/visualize/track_rods.py
@@ -18,8 +18,17 @@ parser.add_argument(
     default=0,
     help="phase index"
 )
+parser.add_argument(
+    "--index_begin",
+    "-i",
+    nargs="?",
+    type=int,
+    default=0,
+    help="index from which loop starts",
+)
 args = parser.parse_args()
 phase_index = args.phase
+index_begin = args.index_begin
 
 simulation_phase = simulation_phases[phase_index]
 total_steps = simulation_phase["total_steps"]
@@ -36,7 +45,7 @@ fig_folderpath = root_folderpath + "fig/"
 if with_boundary is True:
     boundary_folderpath = root_folderpath + "boundary/"
 
-for time in range(0, total_steps, step_interval_for_output):
+for time in range(index_begin, total_steps, step_interval_for_output):
     time_str = str(time).zfill(steps_digits)
     data_filename = "segments" + time_str + ".dat"
     fig_filename = "segments" + time_str + ".png"

--- a/visualize/track_rods.py
+++ b/visualize/track_rods.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 
 import make_fig_of_snapshot as mksnap
@@ -7,10 +8,19 @@ print("parameter file is " + parameter_file)
 with open(parameter_file) as f:
     params = json.load(f)
 simulation_phases = params["phases"]
-with_boundary = params["with_boundary"]
 step_interval_for_output = params["step_interval_for_output"]
 
-phase_index = 0
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "--phase", "-p",
+    nargs="?",
+    type=int,
+    default=0,
+    help="phase index"
+)
+args = parser.parse_args()
+phase_index = args.phase
+
 simulation_phase = simulation_phases[phase_index]
 total_steps = simulation_phase["total_steps"]
 steps_digits = len(str(total_steps))

--- a/visualize/track_rods.py
+++ b/visualize/track_rods.py
@@ -8,6 +8,7 @@ print("parameter file is " + parameter_file)
 with open(parameter_file) as f:
     params = json.load(f)
 simulation_phases = params["phases"]
+with_boundary = "boundary" in params["data_types"]
 step_interval_for_output = params["step_interval_for_output"]
 
 parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Issue

Close #4  

## Implementation policy
- Use `argparse`
- Add parameter `data_types`

## What we did
- Import `argparse`
- Add arguments `phase` and `index_begin`
- Add a new parameter called `data_types` and use it in several scripts

## Result
Now you can run the script for visualization like...
```bash
# first phase
python3 visualize/track_rods.py --phase 0
# second phase with initial index set to 50000
python3 visualize/track_rods.py --phase 1 -i 50000
```